### PR TITLE
more special chars in tags/project names allowed

### DIFF
--- a/src/TaskManager.php
+++ b/src/TaskManager.php
@@ -28,7 +28,7 @@ use ProxyManager\Proxy\ValueHolderInterface;
  */
 class TaskManager
 {
-    const PATTERN = '/^[\wäüö\.]*$/i';
+    const PATTERN = '/^[\wäüö\.@_-]*$/i';
 
     /**
      * @var Taskwarrior


### PR DESCRIPTION
taskwarrior allows special chars as @, _ or - in tags and project names, not sure if this list is complete, should I investigate a bit more?